### PR TITLE
Fix stale grayed-out cells when nobody is selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ app/__screenshots__/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Node.js compile cache
+node-compile-cache/

--- a/app/ui/EventDetails.tsx
+++ b/app/ui/EventDetails.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
   useTransition,
 } from "react";
 import { useY } from "react-yjs";
@@ -629,21 +630,20 @@ function EventDetailsFooter({
   );
 }
 
+const HOVER_QUERY = "(hover: hover)";
+
+function subscribeHover(callback: () => void) {
+  const mq = window.matchMedia(HOVER_QUERY);
+  mq.addEventListener("change", callback);
+  return () => mq.removeEventListener("change", callback);
+}
+
 function useSupportsHover() {
-  const [supportsHover, setSupportsHover] = useState(() =>
-    typeof window === "undefined"
-      ? true
-      : window.matchMedia("(hover: hover)").matches,
+  return useSyncExternalStore(
+    subscribeHover,
+    () => window.matchMedia(HOVER_QUERY).matches,
+    () => true,
   );
-
-  useEffect(() => {
-    const mq = window.matchMedia("(hover: hover)");
-    const onChange = () => setSupportsHover(mq.matches);
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-
-  return supportsHover;
 }
 
 function useRememberEvent(event: Partial<CalendarEvent>) {

--- a/app/ui/EventDetails.tsx
+++ b/app/ui/EventDetails.tsx
@@ -84,11 +84,11 @@ export function EventDetails({
   const availabilityMap = yDoc.getMap("availability");
   const availability = useY(availabilityMap) as AvailabilitySet;
 
+  const supportsHover = useSupportsHover();
   const [hoveredUser, setHoveredUser] = useState<UserId | null>(null);
   const [selectedUsers, setSelectedUsers] = useState<Record<UserId, boolean>>(
     {},
   );
-  const hasSelection = Object.values(selectedUsers).some(Boolean);
 
   const [_tooltipTransition, startTooltipTransition] = useTransition();
   const [hoveredCell, setHoveredCell] = useState<HoveredCellData | undefined>();
@@ -318,9 +318,12 @@ export function EventDetails({
                     availabilityForUsers={availabilityForUsers}
                     creatorId={event.creator}
                     names={names}
-                    onHover={(userId) => setHoveredUser(userId)}
                     selectedUsers={selectedUsers}
                     userId={userId}
+                    onHover={(userId) => {
+                      if (!supportsHover) return;
+                      setHoveredUser(userId);
+                    }}
                     onSelect={(userId) => {
                       if (!userId) return;
                       setSelectedUsers((prev) => ({
@@ -402,13 +405,8 @@ export function EventDetails({
                         const hoveredUserIsAvailable =
                           hoveredUser && availableUsers.includes(hoveredUser);
 
-                        // Hover-dim only when comparing against a selection —
-                        // mouse stays on a user item after a toggle-off click,
-                        // so unconditional hover-dim looks like stale state.
                         const hoveredUserIsUnavailable =
-                          hoveredUser &&
-                          hasSelection &&
-                          !availableUsers.includes(hoveredUser);
+                          hoveredUser && !availableUsers.includes(hoveredUser);
 
                         return (
                           <AvailabilityGridCell
@@ -629,6 +627,23 @@ function EventDetailsFooter({
       <MoreButton />
     </footer>
   );
+}
+
+function useSupportsHover() {
+  const [supportsHover, setSupportsHover] = useState(() =>
+    typeof window === "undefined"
+      ? true
+      : window.matchMedia("(hover: hover)").matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(hover: hover)");
+    const onChange = () => setSupportsHover(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return supportsHover;
 }
 
 function useRememberEvent(event: Partial<CalendarEvent>) {

--- a/app/ui/EventDetails.tsx
+++ b/app/ui/EventDetails.tsx
@@ -88,6 +88,7 @@ export function EventDetails({
   const [selectedUsers, setSelectedUsers] = useState<Record<UserId, boolean>>(
     {},
   );
+  const hasSelection = Object.values(selectedUsers).some(Boolean);
 
   const [_tooltipTransition, startTooltipTransition] = useTransition();
   const [hoveredCell, setHoveredCell] = useState<HoveredCellData | undefined>();
@@ -401,8 +402,13 @@ export function EventDetails({
                         const hoveredUserIsAvailable =
                           hoveredUser && availableUsers.includes(hoveredUser);
 
+                        // Hover-dim only when comparing against a selection —
+                        // mouse stays on a user item after a toggle-off click,
+                        // so unconditional hover-dim looks like stale state.
                         const hoveredUserIsUnavailable =
-                          hoveredUser && !availableUsers.includes(hoveredUser);
+                          hoveredUser &&
+                          hasSelection &&
+                          !availableUsers.includes(hoveredUser);
 
                         return (
                           <AvailabilityGridCell


### PR DESCRIPTION
After a select+deselect on the same user without moving the mouse,
hoveredUser stays set (the mouse is still over the user item) and the
hover-dim styling keeps cells grayed even though selectedUsers has no
true entries. Gate the hover-dim on having an active selection so
hover acts as a pure preview (border-only) when no user is selected,
and as a comparison overlay when one is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved hover interaction handling on event details to intelligently detect device capabilities and only activate hover features on devices that support them, enhancing compatibility and user experience across different device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->