### PR TITLE
shorten branch names on staging deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,8 @@ dist
 .pnp.\*
 
 .partykit
+.wrangler/
+.dev.vars*
 .DS_Store
 app/__screenshots__/
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,7 @@ BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 MAX_PREVIEW_BRANCH_NAME_LENGTH=25
 COMMIT_HASH=${COMMIT_HASH:-$(git rev-parse --short HEAD)}
 
-if [ "$BRANCH_NAME" != "main" ] && [ ${`#BRANCH_NAME`} -gt $MAX_PREVIEW_BRANCH_NAME_LENGTH ]; then
+if [ "$BRANCH_NAME" != "main" ] && [ ${#BRANCH_NAME} -gt $MAX_PREVIEW_BRANCH_NAME_LENGTH ]; then
   # Take first 20 chars of branch name + hyphen + first 4 chars of commit hash = 25 total
   BRANCH_NAME="$(echo "$BRANCH_NAME" | cut -c1-20)-$(echo "$COMMIT_HASH" | cut -c1-4)"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,8 +6,9 @@ BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 MAX_PREVIEW_BRANCH_NAME_LENGTH=25
 COMMIT_HASH=${COMMIT_HASH:-$(git rev-parse --short HEAD)}
 
-if [ "$BRANCH_NAME" != "main" ] && [ ${#BRANCH_NAME} -gt $MAX_PREVIEW_BRANCH_NAME_LENGTH ]; then
-  BRANCH_NAME="$(echo "$BRANCH_NAME" | cut -d- -f1-2)-$(echo "$COMMIT_HASH" | cut -c1-4)"
+if [ "$BRANCH_NAME" != "main" ] && [ ${`#BRANCH_NAME`} -gt $MAX_PREVIEW_BRANCH_NAME_LENGTH ]; then
+  # Take first 20 chars of branch name + hyphen + first 4 chars of commit hash = 25 total
+  BRANCH_NAME="$(echo "$BRANCH_NAME" | cut -c1-20)-$(echo "$COMMIT_HASH" | cut -c1-4)"
 fi
 
 DEPLOY_DATE=$(date -u +"%Y-%m-%d")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,12 @@ set -e
 BRANCH_NAME=${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}
 # Sanitize branch name for partykit preview (must match /^[a-z0-9_-]+$/)
 BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+MAX_PREVIEW_BRANCH_NAME_LENGTH=25
 COMMIT_HASH=${COMMIT_HASH:-$(git rev-parse --short HEAD)}
+
+if [ "$BRANCH_NAME" != "main" ] && [ ${#BRANCH_NAME} -gt $MAX_PREVIEW_BRANCH_NAME_LENGTH ]; then
+  BRANCH_NAME="$(echo "$BRANCH_NAME" | cut -d- -f1-2)-$(echo "$COMMIT_HASH" | cut -c1-4)"
+fi
 
 DEPLOY_DATE=$(date -u +"%Y-%m-%d")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment handling for long preview branch names: added max-length validation and deterministic truncation to produce stable, readable preview identifiers while preserving existing versioning and host-selection behaviour.
  * Updated .gitignore to exclude additional workspace and local environment files (.wrangler/ and .dev.vars*).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->