### PR TITLE
Add vitest unit-test baseline for date, schema, and history parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Unit tests
+        run: pnpm test:unit
+
       # Split system deps from the browser download: the combined
       # `--with-deps` wedges on the interactive `needrestart` apt prompt.
       - name: Install Playwright system deps

--- a/app/schemas.test.ts
+++ b/app/schemas.test.ts
@@ -1,0 +1,169 @@
+import { type } from "arktype";
+import { describe, expect, it } from "vitest";
+
+import {
+  addDays,
+  AvailabilityKey,
+  CalendarEvent,
+  diffDays,
+  IsoDate,
+  isoDate,
+  resolveEventDates,
+  resolveRollingWindow,
+  UserId,
+} from "./schemas";
+
+const utc = (year: number, monthIndex: number, day: number) =>
+  new Date(Date.UTC(year, monthIndex, day));
+
+describe("isoDate", () => {
+  it("formats a UTC date as YYYY-MM-DD", () => {
+    expect(isoDate(utc(2026, 0, 31))).toBe("2026-01-31");
+  });
+});
+
+describe("IsoDate", () => {
+  it("rejects an impossible calendar date", () => {
+    expect(IsoDate("2026-02-30")).toBeInstanceOf(type.errors);
+  });
+
+  it("accepts a valid date and returns the string back", () => {
+    expect(IsoDate("2026-02-28")).toBe("2026-02-28");
+  });
+
+  it("throws on unparseable strings instead of returning errors", () => {
+    // BUG: the IsoDate narrow calls toISOString() on an Invalid Date, so
+    // unparseable strings throw RangeError instead of returning type.errors.
+    expect(() => IsoDate("not-a-date")).toThrow(RangeError);
+  });
+});
+
+describe("diffDays", () => {
+  it("is 0 for the same instant", () => {
+    const date = utc(2026, 5, 10);
+    expect(diffDays(date, date)).toBe(0);
+  });
+
+  it("is 1 for consecutive UTC days", () => {
+    expect(diffDays(utc(2026, 5, 11), utc(2026, 5, 10))).toBe(1);
+  });
+
+  it("is 1 across a DST change (UTC math is immune)", () => {
+    // 2026-03-08 -> 2026-03-09 spans the US spring-forward transition.
+    expect(diffDays(utc(2026, 2, 9), utc(2026, 2, 8))).toBe(1);
+  });
+});
+
+describe("addDays", () => {
+  it("rolls over month boundaries", () => {
+    expect(isoDate(addDays(utc(2026, 0, 31), 1))).toBe("2026-02-01");
+  });
+
+  it("rolls over year boundaries", () => {
+    expect(isoDate(addDays(utc(2026, 11, 31), 1))).toBe("2027-01-01");
+  });
+
+  it("supports negative days", () => {
+    expect(isoDate(addDays(utc(2026, 0, 1), -1))).toBe("2025-12-31");
+  });
+});
+
+describe("resolveRollingWindow", () => {
+  it("returns today and today + days", () => {
+    expect(resolveRollingWindow(7, utc(2026, 5, 10))).toEqual({
+      endDate: "2026-06-17",
+      startDate: "2026-06-10",
+    });
+  });
+});
+
+describe("resolveEventDates", () => {
+  it("derives dates from today for rolling events, ignoring start/end", () => {
+    expect(
+      resolveEventDates(
+        {
+          endDate: IsoDate.assert("2030-01-01"),
+          rolling: 3,
+          startDate: IsoDate.assert("2029-01-01"),
+        },
+        utc(2026, 5, 10),
+      ),
+    ).toEqual({ endDate: "2026-06-13", startDate: "2026-06-10" });
+  });
+
+  it("passes fixed dates through", () => {
+    expect(
+      resolveEventDates(
+        {
+          endDate: IsoDate.assert("2026-06-12"),
+          startDate: IsoDate.assert("2026-06-10"),
+        },
+        utc(2026, 5, 10),
+      ),
+    ).toEqual({ endDate: "2026-06-12", startDate: "2026-06-10" });
+  });
+});
+
+describe("CalendarEvent", () => {
+  const base = {
+    id: "e1",
+    creator: UserId.assert("u1"),
+    name: "Standup",
+  };
+
+  it("accepts a fixed-dates event", () => {
+    expect(() =>
+      CalendarEvent.assert({
+        ...base,
+        endDate: "2026-06-12",
+        startDate: "2026-06-10",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a rolling event", () => {
+    expect(() => CalendarEvent.assert({ ...base, rolling: 3 })).not.toThrow();
+  });
+
+  it("rejects rolling combined with startDate", () => {
+    expect(() =>
+      CalendarEvent.assert({ ...base, rolling: 3, startDate: "2026-06-10" }),
+    ).toThrow();
+  });
+
+  it("rejects an event with neither rolling nor dates", () => {
+    expect(() => CalendarEvent.assert({ ...base })).toThrow();
+  });
+
+  it("rejects rolling: 0", () => {
+    expect(() => CalendarEvent.assert({ ...base, rolling: 0 })).toThrow();
+  });
+
+  it("rejects rolling: 1.5", () => {
+    expect(() => CalendarEvent.assert({ ...base, rolling: 1.5 })).toThrow();
+  });
+});
+
+describe("AvailabilityKey", () => {
+  const userId = UserId.assert("u1");
+  const date = IsoDate.assert("2026-06-10");
+
+  it("joins userId and date with the separator", () => {
+    expect(AvailabilityKey(userId, date)).toBe("u1〷2026-06-10");
+  });
+
+  it("parseToObject round-trips", () => {
+    expect(
+      AvailabilityKey.parseToObject(AvailabilityKey(userId, date)),
+    ).toEqual({ date: "2026-06-10", userId: "u1" });
+  });
+
+  it("parse throws on an invalid date part", () => {
+    expect(() => AvailabilityKey.parse("u1〷not-a-date")).toThrow();
+  });
+
+  it("parse accepts an empty userId part", () => {
+    // BUG: userId part unvalidated - only the date half is checked.
+    expect(AvailabilityKey.parse("〷2026-06-10")).toBe("〷2026-06-10");
+  });
+});

--- a/app/types.d.ts
+++ b/app/types.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="@vitest/browser/providers/playwright" />
-
 declare global {
   namespace NodeJS {
     interface ProcessEnv {

--- a/app/ui/EventHistory/getUpdatesFromUint8Array.test.ts
+++ b/app/ui/EventHistory/getUpdatesFromUint8Array.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { getUpdatesFromUint8Array } from "./getUpdatesFromUint8Array";
+
+const SEPARATOR = [10, 10]; // "\n\n"
+
+/**
+ * Mirrors the server's encodeHistory (party/editor.partyserver.ts):
+ * every part is `label \n\n value \n\n`, including a trailing separator.
+ */
+function encodeHistory(pairs: [string, number[]][]): Uint8Array {
+  const textEncoder = new TextEncoder();
+  const bytes: number[] = [];
+  for (const [label, value] of pairs) {
+    bytes.push(...textEncoder.encode(label), ...SEPARATOR);
+    bytes.push(...value, ...SEPARATOR);
+  }
+  return new Uint8Array(bytes);
+}
+
+describe("getUpdatesFromUint8Array", () => {
+  it("decodes label/value pairs from a server-encoded body", () => {
+    const body = encodeHistory([
+      ["1", [0x01, 0x02]],
+      ["2", [0x03]],
+    ]);
+
+    const updates = getUpdatesFromUint8Array(body);
+
+    expect(updates).toHaveLength(2);
+    expect(updates[0].clock).toBe("1");
+    expect(Array.from(updates[0].value)).toEqual([0x01, 0x02]);
+    expect(updates[1].clock).toBe("2");
+    expect(Array.from(updates[1].value)).toEqual([0x03]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(getUpdatesFromUint8Array(new Uint8Array(0))).toEqual([]);
+  });
+
+  it("ignores the trailing separator the server appends", () => {
+    // The body ends in \n\n; the final empty segment is not emitted.
+    const body = encodeHistory([["7", [0xff]]]);
+    expect(body[body.length - 2]).toBe(10);
+    expect(body[body.length - 1]).toBe(10);
+
+    const updates = getUpdatesFromUint8Array(body);
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].clock).toBe("7");
+    expect(Array.from(updates[0].value)).toEqual([0xff]);
+  });
+
+  it("mis-splits binary values containing the separator bytes", () => {
+    // BUG: binary values containing \n\n are split; fixed by plan 002.
+    // The value [5, 10, 10, 6] splits into [5] and [6]; [6] is then misread
+    // as the next pair's clock label ("\x06") with no value.
+    const body = encodeHistory([["1", [0x05, 0x0a, 0x0a, 0x06]]]);
+
+    const updates = getUpdatesFromUint8Array(body);
+
+    expect(updates).toHaveLength(2);
+    expect(updates[0].clock).toBe("1");
+    expect(Array.from(updates[0].value)).toEqual([0x05]);
+    expect(updates[1].clock).toBe("\x06");
+    expect(updates[1].value).toBeUndefined();
+  });
+});

--- a/app/ui/dateUtils.test.ts
+++ b/app/ui/dateUtils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidDateRange } from "./dateRangeValidation";
+import { eachDayOfInterval } from "./eachDayOfInterval";
+import { getPaddingDays } from "./getPaddingDays";
+
+const utc = (year: number, monthIndex: number, day: number) =>
+  new Date(Date.UTC(year, monthIndex, day));
+
+describe("eachDayOfInterval", () => {
+  it("includes both endpoints", () => {
+    const days = eachDayOfInterval(utc(2026, 5, 1), utc(2026, 5, 3));
+    expect(days).toHaveLength(3);
+    expect(days[0].toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(days[2].toISOString()).toBe("2026-06-03T00:00:00.000Z");
+  });
+
+  it("returns a single day when from === to", () => {
+    expect(eachDayOfInterval(utc(2026, 5, 1), utc(2026, 5, 1))).toHaveLength(1);
+  });
+
+  it("is empty when from > to", () => {
+    expect(eachDayOfInterval(utc(2026, 5, 3), utc(2026, 5, 1))).toEqual([]);
+  });
+
+  it("spans 90 days inclusively as 91 dates", () => {
+    const days = eachDayOfInterval(
+      utc(2026, 0, 1),
+      addUtcDays(utc(2026, 0, 1), 90),
+    );
+    expect(days).toHaveLength(91);
+    expect(new Set(days.map((d) => d.toISOString())).size).toBe(91);
+  });
+});
+
+function addUtcDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * 86400000);
+}
+
+// These inputs are UTC midnights and the suite runs with TZ=UTC
+// (vitest.config.ts), so local getDay() agrees with the UTC weekday.
+describe("getPaddingDays", () => {
+  it("is 0 when the first day is the week start", () => {
+    // 2026-06-01 is a Monday.
+    expect(getPaddingDays(utc(2026, 5, 1), 1)).toBe(0);
+  });
+
+  it("offsets a mid-week first day from the week start", () => {
+    // 2026-06-10 is a Wednesday.
+    expect(getPaddingDays(utc(2026, 5, 10), 1)).toBe(2);
+  });
+
+  it("wraps a Sunday to the end of a Monday-started week", () => {
+    // 2026-06-07 is a Sunday.
+    expect(getPaddingDays(utc(2026, 5, 7), 1)).toBe(6);
+  });
+
+  it("uses Sunday as week start when weekStartsOn is 0", () => {
+    expect(getPaddingDays(utc(2026, 5, 7), 0)).toBe(0);
+    expect(getPaddingDays(utc(2026, 5, 10), 0)).toBe(3);
+  });
+});
+
+describe("isValidDateRange", () => {
+  it("is true when from < to", () => {
+    expect(
+      isValidDateRange({ from: utc(2026, 5, 1), to: utc(2026, 5, 3) }),
+    ).toBe(true);
+  });
+
+  it("is false when from === to", () => {
+    // current behavior: single-day ranges are rejected (strict <).
+    expect(
+      isValidDateRange({ from: utc(2026, 5, 1), to: utc(2026, 5, 1) }),
+    ).toBe(false);
+  });
+
+  it("is false when either side is missing", () => {
+    expect(isValidDateRange({ from: utc(2026, 5, 1), to: undefined })).toBe(
+      false,
+    );
+    expect(isValidDateRange({ from: undefined, to: utc(2026, 5, 3) })).toBe(
+      false,
+    );
+    expect(isValidDateRange({ from: undefined, to: undefined })).toBe(false);
+  });
+
+  it("is false for an inverted range", () => {
+    expect(
+      isValidDateRange({ from: utc(2026, 5, 3), to: utc(2026, 5, 1) }),
+    ).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit",
     "build": "vite build",
     "test": "pnpm build && playwright test",
+    "test:unit": "vitest run",
     "test:ui": "pnpm build && VERBOSE=true playwright test --ui",
     "test:coverage-report": "nyc report --reporter=html --reporter=lcov --report-dir=test/coverage/html --temp-dir=test/coverage",
     "preinstall": "pnpx only-allow pnpm"
@@ -62,7 +63,7 @@
     "typescript-eslint": "^8.28.0",
     "v8-to-istanbul": "^9.3.0",
     "vite": "^6.1.1",
-    "vitest": "^3.0.9",
+    "vitest": "^3.2.6",
     "wrangler": "^4.45.3"
   },
   "pnpm": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
   reporter: process.env.CI ? "github" : "list",
   retries: process.env.CI ? 2 : 0,
   testDir: "./app",
+  // *.test.ts files are vitest unit tests; only *.spec.ts are Playwright's.
+  testMatch: "**/*.spec.ts",
   workers: process.env.CI ? 1 : undefined,
 
   projects: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3)
       vitest:
-        specifier: ^3.0.9
-        version: 3.0.9(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(sass@1.79.3)(tsx@4.19.3)
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(sass@1.79.3)(tsx@4.19.3)
       wrangler:
         specifier: ^4.45.3
         version: 4.45.3(@cloudflare/workers-types@4.20251014.0)
@@ -1970,8 +1970,14 @@ packages:
   '@types/bun@1.2.9':
     resolution: {integrity: sha512-epShhLGQYc4Bv/aceHbmBhOz1XgUnuTZgcxjxk+WXwNyDXavv5QHD1QEFV0FwbTSQtNq6g4ZcV6y0vZakTjswg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -2064,34 +2070,34 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/expect@3.0.9':
-    resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
-  '@vitest/mocker@3.0.9':
-    resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.9':
-    resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
 
-  '@vitest/runner@3.0.9':
-    resolution: {integrity: sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==}
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
 
-  '@vitest/snapshot@3.0.9':
-    resolution: {integrity: sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==}
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
 
-  '@vitest/spy@3.0.9':
-    resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
 
-  '@vitest/utils@3.0.9':
-    resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2297,6 +2303,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
@@ -2335,8 +2350,8 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
-  es-module-lexer@1.6.0:
-    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -2431,8 +2446,8 @@ packages:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
 
-  expect-type@1.2.0:
-    resolution: {integrity: sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exsolve@1.0.7:
@@ -2688,6 +2703,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -2819,6 +2837,9 @@ packages:
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3269,8 +3290,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.8.1:
-    resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -3294,6 +3315,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -3333,16 +3357,16 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.0.2:
-    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -3470,8 +3494,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  vite-node@3.0.9:
-    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -3515,16 +3539,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.0.9:
-    resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.9
-      '@vitest/ui': 3.0.9
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5279,8 +5303,15 @@ snapshots:
     dependencies:
       bun-types: 1.2.9
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0':
     optional: true
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.6': {}
 
@@ -5406,45 +5437,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.0.9':
+  '@vitest/expect@3.2.6':
     dependencies:
-      '@vitest/spy': 3.0.9
-      '@vitest/utils': 3.0.9
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(vite@6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3))':
+  '@vitest/mocker@3.2.6(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(vite@6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3))':
     dependencies:
-      '@vitest/spy': 3.0.9
+      '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.3(@types/node@22.13.14)(typescript@5.8.2)
       vite: 6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3)
 
-  '@vitest/pretty-format@3.0.9':
+  '@vitest/pretty-format@3.2.6':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.9':
+  '@vitest/runner@3.2.6':
     dependencies:
-      '@vitest/utils': 3.0.9
+      '@vitest/utils': 3.2.6
       pathe: 2.0.3
+      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.0.9':
+  '@vitest/snapshot@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 3.0.9
+      '@vitest/pretty-format': 3.2.6
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.0.9':
+  '@vitest/spy@3.2.6':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.4
 
-  '@vitest/utils@3.0.9':
+  '@vitest/utils@3.2.6':
     dependencies:
-      '@vitest/pretty-format': 3.0.9
-      loupe: 3.1.3
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
       tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.14.1):
@@ -5637,6 +5670,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize@1.2.0: {}
 
   deep-eql@5.0.2: {}
@@ -5664,7 +5701,7 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
-  es-module-lexer@1.6.0: {}
+  es-module-lexer@1.7.0: {}
 
   es6-error@4.1.1: {}
 
@@ -5847,7 +5884,7 @@ snapshots:
 
   exit-hook@2.2.1: {}
 
-  expect-type@1.2.0: {}
+  expect-type@1.3.0: {}
 
   exsolve@1.0.7: {}
 
@@ -6082,6 +6119,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -6180,6 +6219,8 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   loupe@3.1.3: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -6718,7 +6759,7 @@ snapshots:
   statuses@2.0.2:
     optional: true
 
-  std-env@3.8.1: {}
+  std-env@3.10.0: {}
 
   stoppable@1.1.0: {}
 
@@ -6738,6 +6779,10 @@ snapshots:
   strip-bom@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   supports-color@10.2.2: {}
 
@@ -6770,11 +6815,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.0.2: {}
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6898,11 +6943,11 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite-node@3.0.9(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3):
+  vite-node@3.2.4(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3)
     transitivePeerDependencies:
@@ -6932,27 +6977,30 @@ snapshots:
       sass: 1.79.3
       tsx: 4.19.3
 
-  vitest@3.0.9(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(sass@1.79.3)(tsx@4.19.3):
+  vitest@3.2.6(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(sass@1.79.3)(tsx@4.19.3):
     dependencies:
-      '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(vite@6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3))
-      '@vitest/pretty-format': 3.0.9
-      '@vitest/runner': 3.0.9
-      '@vitest/snapshot': 3.0.9
-      '@vitest/spy': 3.0.9
-      '@vitest/utils': 3.0.9
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(vite@6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
       chai: 5.2.0
-      debug: 4.4.0
-      expect-type: 1.2.0
+      debug: 4.4.3
+      expect-type: 1.3.0
       magic-string: 0.30.17
       pathe: 2.0.3
-      std-env: 3.8.1
+      picomatch: 4.0.3
+      std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinypool: 1.0.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.1.1(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3)
-      vite-node: 3.0.9(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3)
+      vite-node: 3.2.4(@types/node@22.13.14)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.79.3)(tsx@4.19.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.14

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    env: { TZ: "UTC" },
+    environment: "node",
+    include: ["app/**/*.test.ts", "party/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Part of #26 — implements [`plans/001-unit-test-baseline.md`](https://github.com/hasparus/bear-fit/blob/partyserver/plans/001-unit-test-baseline.md).

- vitest 3.2.6 (patches the critical advisory in <3.2.6) with a minimal node-env config, `pnpm test:unit` script, and a CI step
- 39 tests across `app/schemas.test.ts`, `app/ui/dateUtils.test.ts`, `app/ui/EventHistory/getUpdatesFromUint8Array.test.ts` — timezone-hermetic (`TZ=UTC` in config; verified green under `TZ=America/New_York`)
- `playwright.config.ts` gets `testMatch: "**/*.spec.ts"` so Playwright's default glob stops collecting the new `*.test.ts` files
- Removes a stray `@vitest/browser` types reference

Characterized (not fixed) bugs, with `// BUG:` markers: `IsoDate` throws `RangeError` on unparseable input instead of returning arktype errors; `AvailabilityKey.parse` never validates the userId half; `getUpdatesFromUint8Array` mis-splits binary values containing `\n\n` (fixed by the PR stacked on this one).

Verification: `pnpm test:unit` 39/39 in three TZs, full Playwright suite green locally (34/34 after the base-branch `AppHeader` tab-order spec fix), typecheck + lint clean.

Note: conflicts trivially with the dependency-pass PR on `package.json` (both bump vitest) — whichever lands second rebases.