### PR TITLE
Use length-prefixed framing for event history payloads

### DIFF
--- a/app/ui/EventHistory/getUpdatesFromUint8Array.test.ts
+++ b/app/ui/EventHistory/getUpdatesFromUint8Array.test.ts
@@ -2,67 +2,75 @@ import { describe, expect, it } from "vitest";
 
 import { getUpdatesFromUint8Array } from "./getUpdatesFromUint8Array";
 
-const SEPARATOR = [10, 10]; // "\n\n"
-
 /**
  * Mirrors the server's encodeHistory (party/editor.partyserver.ts):
- * every part is `label \n\n value \n\n`, including a trailing separator.
+ * per record, [4-byte BE uint32 clock][4-byte BE uint32 byteLength][update bytes].
  */
-function encodeHistory(pairs: [string, number[]][]): Uint8Array {
-  const textEncoder = new TextEncoder();
-  const bytes: number[] = [];
-  for (const [label, value] of pairs) {
-    bytes.push(...textEncoder.encode(label), ...SEPARATOR);
-    bytes.push(...value, ...SEPARATOR);
+function encodeHistory(records: [number, number[]][]): Uint8Array {
+  const totalSize = records.reduce((acc, [, value]) => acc + 8 + value.length, 0);
+  const body = new Uint8Array(totalSize);
+  const view = new DataView(body.buffer);
+  let offset = 0;
+  for (const [clock, value] of records) {
+    view.setUint32(offset, clock);
+    view.setUint32(offset + 4, value.length);
+    body.set(value, offset + 8);
+    offset += 8 + value.length;
   }
-  return new Uint8Array(bytes);
+  return body;
 }
 
 describe("getUpdatesFromUint8Array", () => {
-  it("decodes label/value pairs from a server-encoded body", () => {
+  it("round-trips records, including values containing consecutive 0x0A bytes", () => {
+    /**
+     * [10, 10, 10, 10] was the killer payload for the old "\n\n"-separated
+     * format (mis-split into phantom records); with length-prefixed framing
+     * it round-trips intact.
+     */
     const body = encodeHistory([
-      ["1", [0x01, 0x02]],
-      ["2", [0x03]],
+      [1, [1, 2, 3]],
+      [2, [10, 10, 10, 10]],
     ]);
 
     const updates = getUpdatesFromUint8Array(body);
 
     expect(updates).toHaveLength(2);
     expect(updates[0].clock).toBe("1");
-    expect(Array.from(updates[0].value)).toEqual([0x01, 0x02]);
+    expect(Array.from(updates[0].value)).toEqual([1, 2, 3]);
     expect(updates[1].clock).toBe("2");
-    expect(Array.from(updates[1].value)).toEqual([0x03]);
+    expect(Array.from(updates[1].value)).toEqual([10, 10, 10, 10]);
   });
 
   it("returns [] for empty input", () => {
     expect(getUpdatesFromUint8Array(new Uint8Array(0))).toEqual([]);
   });
 
-  it("ignores the trailing separator the server appends", () => {
-    // The body ends in \n\n; the final empty segment is not emitted.
-    const body = encodeHistory([["7", [0xff]]]);
-    expect(body[body.length - 2]).toBe(10);
-    expect(body[body.length - 1]).toBe(10);
+  it("returns only complete records for a truncated body, without throwing", () => {
+    const body = encodeHistory([
+      [1, [0x05, 0x06]],
+      [2, [0x07, 0x08, 0x09]],
+    ]);
+    const truncated = body.slice(0, body.length - 2);
 
-    const updates = getUpdatesFromUint8Array(body);
+    const updates = getUpdatesFromUint8Array(truncated);
 
     expect(updates).toHaveLength(1);
-    expect(updates[0].clock).toBe("7");
-    expect(Array.from(updates[0].value)).toEqual([0xff]);
+    expect(updates[0].clock).toBe("1");
+    expect(Array.from(updates[0].value)).toEqual([0x05, 0x06]);
   });
 
-  it("mis-splits binary values containing the separator bytes", () => {
-    // BUG: binary values containing \n\n are split; fixed by plan 002.
-    // The value [5, 10, 10, 6] splits into [5] and [6]; [6] is then misread
-    // as the next pair's clock label ("\x06") with no value.
-    const body = encodeHistory([["1", [0x05, 0x0a, 0x0a, 0x06]]]);
+  it("preserves uint32-max clocks and record order", () => {
+    const body = encodeHistory([
+      [4294967295, [0xaa]],
+      [7, [0xbb]],
+      [3, [0xcc]],
+    ]);
 
     const updates = getUpdatesFromUint8Array(body);
 
-    expect(updates).toHaveLength(2);
-    expect(updates[0].clock).toBe("1");
-    expect(Array.from(updates[0].value)).toEqual([0x05]);
-    expect(updates[1].clock).toBe("\x06");
-    expect(updates[1].value).toBeUndefined();
+    expect(updates.map((u) => u.clock)).toEqual(["4294967295", "7", "3"]);
+    expect(Array.from(updates[0].value)).toEqual([0xaa]);
+    expect(Array.from(updates[1].value)).toEqual([0xbb]);
+    expect(Array.from(updates[2].value)).toEqual([0xcc]);
   });
 });

--- a/app/ui/EventHistory/getUpdatesFromUint8Array.ts
+++ b/app/ui/EventHistory/getUpdatesFromUint8Array.ts
@@ -1,27 +1,21 @@
+/**
+ * Decodes the length-prefixed history wire format produced by the server's
+ * encodeHistory (party/editor.partyserver.ts). Per record:
+ * [4-byte big-endian uint32: clock][4-byte big-endian uint32: byteLength][update bytes]
+ */
 export function getUpdatesFromUint8Array(body: Uint8Array) {
-  const textDecoder = new TextDecoder();
-  const parts: Uint8Array[] = [];
-  let start = 0;
-
-  for (let i = 0; i < body.length - 1; i++) {
-    if (body[i] === 10 && body[i + 1] === 10) {
-      parts.push(body.slice(start, i));
-      start = i + 2;
-      i++;
-    }
-  }
-
-  if (start < body.length) {
-    parts.push(body.slice(start));
-  }
-
   const updates: { clock: string; value: Uint8Array }[] = [];
-
-  for (let i = 0; i < parts.length; i += 2) {
-    const clockOrSv = textDecoder.decode(parts[i]);
-    const value = parts[i + 1];
-    updates.push({ clock: clockOrSv, value });
+  const view = new DataView(body.buffer, body.byteOffset, body.byteLength);
+  let offset = 0;
+  while (offset + 8 <= body.length) {
+    const clock = view.getUint32(offset);
+    const length = view.getUint32(offset + 4);
+    if (offset + 8 + length > body.length) break; // truncated payload — stop cleanly
+    updates.push({
+      clock: String(clock),
+      value: body.slice(offset + 8, offset + 8 + length),
+    });
+    offset += 8 + length;
   }
-
   return updates;
 }

--- a/party/editor.partyserver.ts
+++ b/party/editor.partyserver.ts
@@ -27,9 +27,6 @@ interface UpdateRow {
 const TABLE_DOCUMENTS = "documents";
 const TABLE_UPDATES = "document_updates";
 
-const TEXT_ENCODER = new TextEncoder();
-const HISTORY_SEPARATOR = TEXT_ENCODER.encode("\n\n");
-
 export class EditorPartyServer extends YServer<EditorEnv> {
   static callbackOptions = {
     debounceMaxWait: 5_000,
@@ -229,25 +226,24 @@ export class EditorPartyServer extends YServer<EditorEnv> {
     }
   }
 
+  /**
+   * Length-prefixed framing, per record:
+   * [4-byte big-endian uint32: clock][4-byte big-endian uint32: update byteLength][update bytes]
+   */
   private encodeHistory(rows: UpdateRow[]): Uint8Array {
-    const parts: Uint8Array[] = [];
-    const appendPair = (label: string, value: Uint8Array) => {
-      parts.push(TEXT_ENCODER.encode(label));
-      parts.push(HISTORY_SEPARATOR);
-      parts.push(value);
-      parts.push(HISTORY_SEPARATOR);
-    };
-
-    for (const row of rows) {
-      appendPair(String(row.clock), new Uint8Array(row.update));
-    }
-
-    const totalSize = parts.reduce((acc, part) => acc + part.length, 0);
+    const totalSize = rows.reduce(
+      (acc, row) => acc + 8 + new Uint8Array(row.update).byteLength,
+      0,
+    );
     const body = new Uint8Array(totalSize);
+    const view = new DataView(body.buffer);
     let offset = 0;
-    for (const part of parts) {
-      body.set(part, offset);
-      offset += part.length;
+    for (const row of rows) {
+      const update = new Uint8Array(row.update);
+      view.setUint32(offset, row.clock);
+      view.setUint32(offset + 4, update.byteLength);
+      body.set(update, offset + 8);
+      offset += 8 + update.byteLength;
     }
     return body;
   }


### PR DESCRIPTION
Part of #26 — implements [`plans/002-binary-safe-history-format.md`](https://github.com/hasparus/bear-fit/blob/partyserver/plans/002-binary-safe-history-format.md). **Stacked on #27** (uses its vitest harness); retarget to `partyserver` after #27 merges.

The `/history` endpoint joined **binary** Yjs updates with a `\n\n` separator and the client split on any occurrence of those two bytes. Binary updates can legitimately contain `0x0A 0x0A`, which shifted clock/payload pairs out of phase — corrupting the Version History dialog, and Restore could write that corruption back into the live event. Data-dependent and intermittent.

Replaces the format with length-prefixed framing — `[u32 BE clock][u32 BE byteLength][update bytes]` per record — symmetric encoder (`party/editor.partyserver.ts`) and decoder (`app/ui/EventHistory/getUpdatesFromUint8Array.ts`), net −10 lines. The `// BUG` characterization test from #27 now asserts the correct round-trip, plus truncation, empty-body, uint32-max-clock, and ordering cases.

Client and server deploy atomically in one Worker, so no version negotiation is needed.

Verification: `pnpm test:unit` 39/39; `EventHistory.spec.ts` e2e green on both browsers; typecheck + lint clean.