### PR TITLE
Read event dates with UTC getters in calendar grid and edit form

### DIFF
--- a/app/ui/AvailabilityGridCell.tsx
+++ b/app/ui/AvailabilityGridCell.tsx
@@ -23,8 +23,11 @@ export function AvailabilityGridCell({
   return (
     <button
       type="button"
-      aria-label={day.toLocaleDateString(undefined, { dateStyle: "full" })}
       disabled={disabled}
+      aria-label={day.toLocaleDateString(undefined, {
+        dateStyle: "full",
+        timeZone: "UTC",
+      })}
       className={cn(
         "group flex items-center justify-center rounded-md size-10 select-none hover:border-neutral-200 bg-neutral-100 hover:border-2 relative transition-all border-transparent",
         className,
@@ -37,7 +40,7 @@ export function AvailabilityGridCell({
       }}
       {...rest}
     >
-      {day.toLocaleDateString("en-US", { day: "numeric" })}
+      {day.toLocaleDateString("en-US", { day: "numeric", timeZone: "UTC" })}
     </button>
   );
 }

--- a/app/ui/EditEventForm.tsx
+++ b/app/ui/EditEventForm.tsx
@@ -2,7 +2,12 @@ import Clarity from "@microsoft/clarity";
 import { useState } from "react";
 import { type DateRange } from "react-day-picker";
 
-import { type CalendarEvent, resolveEventDates } from "../schemas";
+import {
+  addDays,
+  type CalendarEvent,
+  resolveEventDates,
+  startOfTodayUtc,
+} from "../schemas";
 import { type EventDatesPatch } from "../shared-data";
 import { handleCalendarArrowKeys } from "./DateRangePicker";
 import {
@@ -20,6 +25,8 @@ export interface EditEventFormProps {
 
 export function EditEventForm({ event, onSubmit }: EditEventFormProps) {
   const { endDate, startDate } = resolveEventDates(event);
+  // UTC-midnight seeds; DateRangePicker pins react-day-picker to timeZone="UTC",
+  // so every date it receives or emits is bucketed by its UTC day.
   const seedStart = startDate ? new Date(startDate) : undefined;
   const seedEnd = endDate ? new Date(endDate) : undefined;
 
@@ -30,7 +37,7 @@ export function EditEventForm({ event, onSubmit }: EditEventFormProps) {
     }),
   );
 
-  const today = new Date();
+  const today = startOfTodayUtc();
   const earliestDate = seedStart && seedStart < today ? seedStart : today;
   const initialRange: DateRange | undefined =
     seedStart && seedEnd ? { from: seedStart, to: seedEnd } : undefined;
@@ -77,12 +84,9 @@ function unfoldDateRange(range: DateRange): Date[] {
   const { from, to } = range;
   if (!from || !to) return [];
   const dates: Date[] = [];
-  for (
-    let date = new Date(from);
-    date <= to;
-    date.setDate(date.getDate() + 1)
-  ) {
-    dates.push(new Date(date));
+  // inputs are UTC-midnight dates, so step in UTC days (immune to DST shifts)
+  for (let date = new Date(from); date <= to; date = addDays(date, 1)) {
+    dates.push(date);
   }
   return dates;
 }

--- a/app/ui/EventDetails.tsx
+++ b/app/ui/EventDetails.tsx
@@ -19,6 +19,7 @@ import {
   IsoDate,
   isoDate,
   resolveEventDates,
+  startOfTodayUtc,
   type UserId,
 } from "../schemas";
 import { AvailabilityKey } from "../schemas";
@@ -126,11 +127,11 @@ export function EventDetails({
   );
 
   const groupedDays = eachDayOfInterval(
-    startDate ? new Date(startDate) : new Date(),
-    endDate ? new Date(endDate) : new Date(),
+    startDate ? new Date(startDate) : startOfTodayUtc(),
+    endDate ? new Date(endDate) : startOfTodayUtc(),
   ).reduce(
     (acc, day) => {
-      const monthKey = `${day.getFullYear()}-${day.getMonth()}`;
+      const monthKey = `${day.getUTCFullYear()}-${day.getUTCMonth()}`;
       if (!acc[monthKey]) {
         acc[monthKey] = [];
       }
@@ -276,11 +277,15 @@ export function EventDetails({
                 {startDate && endDate ? (
                   <>
                     <time dateTime={startDate}>
-                      {new Date(startDate).toLocaleDateString()}
+                      {new Date(startDate).toLocaleDateString(undefined, {
+                        timeZone: "UTC",
+                      })}
                     </time>
                     {" - "}
                     <time dateTime={endDate}>
-                      {new Date(endDate).toLocaleDateString()}
+                      {new Date(endDate).toLocaleDateString(undefined, {
+                        timeZone: "UTC",
+                      })}
                     </time>
                     {event.rolling && (
                       <RollingWindowIndicator days={event.rolling} />
@@ -353,6 +358,7 @@ export function EventDetails({
                     <div className="mb-2 mt-4 first:mt-2">
                       {monthDays[0].toLocaleDateString("en-US", {
                         month: "long",
+                        timeZone: "UTC",
                       })}
                     </div>
                     <div className="grid grid-cols-7 gap-1 relative">

--- a/app/ui/dateUtils.test.ts
+++ b/app/ui/dateUtils.test.ts
@@ -37,9 +37,16 @@ function addUtcDays(date: Date, days: number): Date {
   return new Date(date.getTime() + days * 86400000);
 }
 
-// These inputs are UTC midnights and the suite runs with TZ=UTC
-// (vitest.config.ts), so local getDay() agrees with the UTC weekday.
+// These inputs are UTC midnights and getPaddingDays reads getUTCDay(),
+// so the expectations hold in every host timezone. Run the suite with
+// TZ=America/Los_Angeles and TZ=Pacific/Kiritimati as regression proof.
 describe("getPaddingDays", () => {
+  it("reads the weekday in UTC regardless of host timezone", () => {
+    // 2026-07-01 is a Wednesday; with the week starting Monday, padding = 2.
+    // Before the getUTCDay() fix this was 1 under TZ=America/Los_Angeles.
+    expect(getPaddingDays(utc(2026, 6, 1), 1)).toBe(2);
+  });
+
   it("is 0 when the first day is the week start", () => {
     // 2026-06-01 is a Monday.
     expect(getPaddingDays(utc(2026, 5, 1), 1)).toBe(0);
@@ -58,6 +65,29 @@ describe("getPaddingDays", () => {
   it("uses Sunday as week start when weekStartsOn is 0", () => {
     expect(getPaddingDays(utc(2026, 5, 7), 0)).toBe(0);
     expect(getPaddingDays(utc(2026, 5, 10), 0)).toBe(3);
+  });
+});
+
+describe("calendar month grouping", () => {
+  // Replicates the monthKey reduce in EventDetails.tsx over dates parsed
+  // from stored IsoDate strings (UTC midnights). With UTC getters a July
+  // event groups under a single July key in every host timezone; local
+  // getters put 2026-07-01 under June for any user west of UTC.
+  it("groups an early-July range under a single month key in any timezone", () => {
+    const groups = eachDayOfInterval(
+      new Date("2026-07-01"),
+      new Date("2026-07-03"),
+    ).reduce(
+      (acc, day) => {
+        const monthKey = `${day.getUTCFullYear()}-${day.getUTCMonth()}`;
+        (acc[monthKey] ??= []).push(day);
+        return acc;
+      },
+      {} as Record<string, Date[]>,
+    );
+
+    expect(Object.keys(groups)).toEqual(["2026-6"]);
+    expect(groups["2026-6"]).toHaveLength(3);
   });
 });
 

--- a/app/ui/getPaddingDays.tsx
+++ b/app/ui/getPaddingDays.tsx
@@ -1,4 +1,4 @@
 export function getPaddingDays(firstDay: Date, weekStartsOn: number): number {
-  const day = firstDay.getDay();
+  const day = firstDay.getUTCDay();
   return (day - weekStartsOn + 7) % 7;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    env: { TZ: "UTC" },
+    env: { TZ: process.env.TZ ?? "UTC" },
     environment: "node",
     include: ["app/**/*.test.ts", "party/**/*.test.ts"],
   },


### PR DESCRIPTION
Part of #26 — implements [`plans/003-utc-consistent-calendar-math.md`](https://github.com/hasparus/bear-fit/blob/partyserver/plans/003-utc-consistent-calendar-math.md). **Stacked on #27** (extends its unit tests); retarget to `partyserver` after #27 merges.

Event dates are stored as date-only ISO strings, parsed as **UTC midnight** — but the grid read them with **local-time** getters. For any user west of UTC, the month grouping key, weekday padding, and date labels all shifted one day back (a July 1 event rendered under a "June" header in the wrong weekday column). Users east of UTC never see it, which is why it survived.

- `monthKey` uses `getUTCFullYear`/`getUTCMonth`; `getPaddingDays` uses `getUTCDay`; all event-date `toLocaleDateString` calls pin `timeZone: "UTC"` (grid header, start/end times, cell day numbers + aria-labels)
- `EditEventForm`: `today` is `startOfTodayUtc()`; `unfoldDateRange` steps via the existing UTC `addDays` (DST-immune)
- Investigated and **dropped** the plan's proposed local↔UTC boundary helpers: `DateRangePicker` already pins react-day-picker to `timeZone="UTC"` (verified down to date-fns internals), so picker output is UTC-day-bucketed — adding the conversion would have *introduced* an off-by-one for UTC+14
- `vitest.config.ts` now respects an explicit `TZ` override so TZ-matrix runs actually vary the zone

Invariant for review: storage = IsoDate = UTC days; the picker is UTC-pinned; every read of an ISO-parsed date uses UTC getters or UTC-pinned formatting. Regression proof: reverting `getUTCDay` fails 5 tests under `TZ=America/Los_Angeles`.

Verification: 41 unit tests green under `TZ=UTC`, `America/Los_Angeles`, and `Pacific/Kiritimati`; full Playwright suite 34/34 on both browsers; typecheck + lint clean.