### PR TITLE
Require internal auth for occupancy updates; time-bound dashboard auth

### DIFF
--- a/.ssh/sign-message.tsx
+++ b/.ssh/sign-message.tsx
@@ -1,15 +1,21 @@
 #! /usr/bin/env bun
 
-// usage: bun .ssh/sign-message.tsx <message> [outDir]
-// example: bun .ssh/sign-message.tsx "my message" ./test
 
-const message = process.argv[2];
-const outDir = process.argv[3] || ".";
+import { AUTH_MESSAGE_PREFIX } from "../party/rooms";
 
-if (!message) {
-  console.error("Message is required. Usage: bun sign-message.tsx <message>");
+const outDir = process.argv[2] || ".";
+const timestampArg = process.argv[3];
+
+const timestamp = timestampArg ? Number(timestampArg) : Date.now();
+
+if (!Number.isSafeInteger(timestamp)) {
+  console.error(
+    `Invalid timestamp "${timestampArg}". Usage: bun sign-message.tsx [outDir] [timestamp]`,
+  );
   process.exit(1);
 }
+
+const message = `${AUTH_MESSAGE_PREFIX}${timestamp}`;
 
 const file = await Bun.file(
   new URL(`${outDir}/id_ed25519`, import.meta.url),
@@ -26,6 +32,6 @@ const signature = await crypto.subtle.sign(
   new TextEncoder().encode(message),
 );
 
-console.log(Buffer.from(signature).toString("base64"));
+console.log(`${timestamp}.${Buffer.from(signature).toString("base64")}`);
 
 export {};

--- a/app/Dashboard.spec.ts
+++ b/app/Dashboard.spec.ts
@@ -1,4 +1,4 @@
-import type { APIRequestContext } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 import { spawnSync } from "node:child_process";
 import path from "node:path";
@@ -7,10 +7,19 @@ import { expect, test } from "../test";
 
 test.setTimeout(45_000);
 
-const AUTH_MESSAGE = "dashboard";
 const SIGN_SCRIPT = path.join(process.cwd(), ".ssh", "sign-message.tsx");
-const SIGNATURE = (() => {
-  const result = spawnSync("bun", [SIGN_SCRIPT, AUTH_MESSAGE, "./test"], {
+const OCCUPANCY_ENDPOINT = "/parties/rooms/index";
+
+/**
+ * Signs the dashboard auth message with the committed TEST key and returns
+ * the `<timestamp>.<signatureB64>` token the dashboard input expects.
+ */
+function signAuthToken(timestamp?: number): string {
+  const args = [SIGN_SCRIPT, "./test"];
+  if (timestamp !== undefined) {
+    args.push(String(timestamp));
+  }
+  const result = spawnSync("bun", args, {
     cwd: process.cwd(),
     encoding: "utf-8",
   });
@@ -23,39 +32,61 @@ const SIGNATURE = (() => {
     );
   }
   return result.stdout.trim();
-})();
-const OCCUPANCY_ENDPOINT = "/parties/rooms/index";
+}
 
-async function updateRoomCount(
-  request: APIRequestContext,
-  room: string,
-  count: number,
-) {
+/**
+ * Opens a real WebSocket connection to an event room so the editor server
+ * reports occupancy to the occupancy server through the internal channel.
+ * The socket stays open for the lifetime of the page.
+ */
+async function connectToRoom(page: Page, room: string) {
+  await page.evaluate(async (roomId) => {
+    const protocol = location.protocol === "https:" ? "wss" : "ws";
+    const socket = new WebSocket(
+      `${protocol}://${location.host}/parties/main/${roomId}`,
+    );
+    interface WindowWithSockets {
+      __testSockets?: WebSocket[];
+    }
+    const win = window as WindowWithSockets;
+    win.__testSockets ??= [];
+    win.__testSockets.push(socket);
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", () => resolve());
+      socket.addEventListener("error", () =>
+        reject(new Error(`failed to connect to room ${roomId}`)),
+      );
+    });
+  }, room);
+}
+
+test("occupancy update endpoint rejects public POSTs", async ({ request }) => {
   const response = await request.post(OCCUPANCY_ENDPOINT, {
-    data: { count, room },
+    data: { count: 999, room: `forged-room-${Date.now()}` },
   });
 
-  if (!response.ok()) {
-    throw new Error(
-      `Failed to update room "${room}" to ${count}: ${response.status()} ${await response.text()}`,
-    );
-  }
-}
+  expect(response.status()).toBe(403);
+  expect(await response.json()).toEqual({ error: "forbidden" });
+
+  const publicInfo = await request.get(OCCUPANCY_ENDPOINT);
+  expect(publicInfo.ok()).toBeTruthy();
+  expect(await publicInfo.json()).toEqual({
+    activeConnections: expect.any(Number),
+    rooms: expect.any(Number),
+  });
+});
 
 test("dashboard only shows per-room details after successful authorization", async ({
   page,
-  request,
 }) => {
   const roomA = `room-a-${Date.now()}`;
   const roomB = `room-b-${Date.now()}`;
 
-  await updateRoomCount(request, roomA, 0);
-  await updateRoomCount(request, roomB, 0);
-  await updateRoomCount(request, roomA, 3);
-  await updateRoomCount(request, roomB, 5);
-
   await page.goto("/dashboard");
   await expect(page).toHaveURL(/\/dashboard$/);
+
+  await connectToRoom(page, roomA);
+  await connectToRoom(page, roomB);
 
   const summary = page.locator(".bg-neutral-100 dl");
   await expect(summary).toBeVisible();
@@ -63,7 +94,7 @@ test("dashboard only shows per-room details after successful authorization", asy
   await expect(summary.getByText("Active connections:")).toBeVisible();
   await expect(page.locator(".bg-neutral-100 ul li")).toHaveCount(0);
 
-  await page.getByPlaceholder("admin access key").fill(SIGNATURE);
+  await page.getByPlaceholder("admin access key").fill(signAuthToken());
   await page.getByRole("button", { name: "Authorize" }).click();
 
   const roomList = page.locator(".bg-neutral-100 ul");
@@ -71,16 +102,34 @@ test("dashboard only shows per-room details after successful authorization", asy
   await expect(
     roomList
       .getByRole("listitem")
-      .filter({ hasText: `${roomA}: 3 connections` }),
+      .filter({ hasText: `${roomA}: 1 connections` }),
   ).toBeVisible();
   await expect(
     roomList
       .getByRole("listitem")
-      .filter({ hasText: `${roomB}: 5 connections` }),
+      .filter({ hasText: `${roomB}: 1 connections` }),
   ).toBeVisible();
 
   await expect(summary).toHaveCount(0);
+});
 
-  await updateRoomCount(request, roomA, 0);
-  await updateRoomCount(request, roomB, 0);
+test("dashboard rejects stale auth tokens", async ({ page }) => {
+  const room = `room-stale-${Date.now()}`;
+  const staleToken = signAuthToken(Date.now() - 6 * 60_000);
+
+  await page.goto("/dashboard");
+  await expect(page).toHaveURL(/\/dashboard$/);
+
+  await connectToRoom(page, room);
+
+  const summary = page.locator(".bg-neutral-100 dl");
+  await expect(summary).toBeVisible();
+
+  await page.getByPlaceholder("admin access key").fill(staleToken);
+  await page.getByRole("button", { name: "Authorize" }).click();
+
+  await page.waitForTimeout(2_000);
+
+  await expect(page.locator(".bg-neutral-100 ul")).toHaveCount(0);
+  await expect(summary).toBeVisible();
 });

--- a/app/dashboard/index.tsx
+++ b/app/dashboard/index.tsx
@@ -83,14 +83,19 @@ function Dashboard() {
           onSubmit={(event) => {
             event.preventDefault();
             const formData = new FormData(event.currentTarget);
-            const signature = formData.get("signature")?.toString();
-            if (signature) {
-              ws.send(
-                JSON.stringify({
-                  type: "auth",
-                  payload: { signature },
-                } satisfies ClientMessage),
-              );
+            const token = formData.get("signature")?.toString();
+            const separatorIndex = token?.indexOf(".") ?? -1;
+            if (token && separatorIndex > 0) {
+              const timestamp = Number(token.slice(0, separatorIndex));
+              const signature = token.slice(separatorIndex + 1);
+              if (Number.isSafeInteger(timestamp) && signature) {
+                ws.send(
+                  JSON.stringify({
+                    type: "auth",
+                    payload: { signature, timestamp },
+                  } satisfies ClientMessage),
+                );
+              }
             }
           }}
         >

--- a/party/editor.partyserver.ts
+++ b/party/editor.partyserver.ts
@@ -261,8 +261,11 @@ export class EditorPartyServer extends YServer<EditorEnv> {
       const count = Array.from(this.getConnections()).length;
       await stub.fetch("https://occupancy.internal/update", {
         body: JSON.stringify({ count, room: this.name }),
-        headers: { "Content-Type": "application/json" },
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-occupancy-internal": "1",
+        },
       });
     } catch (error) {
       console.error("failed to notify occupancy server", error);

--- a/party/occupancy.partyserver.ts
+++ b/party/occupancy.partyserver.ts
@@ -2,10 +2,11 @@ import { type } from "arktype";
 import { type Connection, Server } from "partyserver";
 
 import {
+  AUTH_MESSAGE_MAX_AGE,
+  AUTH_MESSAGE_PREFIX,
   AUTHORIZATION_EXPIRATION_TIME,
   base64ToArrayBuffer,
   ClientMessage,
-  HARDCODED_AUTH_MESSAGE_NOT_SMART,
   makePublicRoomInfo,
   type Rooms,
   textEncoder,
@@ -60,7 +61,11 @@ export class OccupancyPartyServer extends Server<OccupancyEnv> {
 
     if (parsed.type === "auth") {
       try {
-        const verified = await this.verifySignature(parsed.payload.signature);
+        const { signature, timestamp } = parsed.payload;
+        if (Math.abs(Date.now() - timestamp) > AUTH_MESSAGE_MAX_AGE) {
+          return;
+        }
+        const verified = await this.verifySignature(signature, timestamp);
         if (verified) {
           this.authorizeConnection(connection);
         }
@@ -79,6 +84,14 @@ export class OccupancyPartyServer extends Server<OccupancyEnv> {
     }
 
     if (request.method === "POST") {
+      const url = new URL(request.url);
+      if (
+        url.hostname !== "occupancy.internal" ||
+        request.headers.get("x-occupancy-internal") !== "1"
+      ) {
+        return Response.json({ error: "forbidden" }, { status: 403 });
+      }
+
       const body = await request.json();
       const validated = UpdateFromRoom(body);
       if (validated instanceof type.errors) {
@@ -136,9 +149,14 @@ export class OccupancyPartyServer extends Server<OccupancyEnv> {
     );
   }
 
-  private async verifySignature(signatureB64: string): Promise<boolean> {
+  private async verifySignature(
+    signatureB64: string,
+    timestamp: number,
+  ): Promise<boolean> {
     try {
-      const encoded = textEncoder.encode(HARDCODED_AUTH_MESSAGE_NOT_SMART);
+      const encoded = textEncoder.encode(
+        AUTH_MESSAGE_PREFIX + String(timestamp),
+      );
       const signature = base64ToArrayBuffer(signatureB64);
       const publicKey = await this.publicKeyPromise;
       return crypto.subtle.verify(

--- a/party/rooms.ts
+++ b/party/rooms.ts
@@ -5,7 +5,8 @@ type ConnectionsCount = number;
 export type Rooms = Record<RoomId, ConnectionsCount>;
 
 // we could use a jwt with iat and exp, but this is fine for now
-export const HARDCODED_AUTH_MESSAGE_NOT_SMART = "dashboard";
+export const AUTH_MESSAGE_PREFIX = "dashboard:";
+export const AUTH_MESSAGE_MAX_AGE = 1000 * 60 * 5;
 export const AUTHORIZATION_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 1; // 1 day
 
 export const UpdateFromRoom = type({ count: "number", room: "string" });
@@ -15,6 +16,7 @@ export const ClientMessage = type({
   type: "'auth'",
   payload: {
     signature: "string",
+    timestamp: "number",
   },
 });
 export type ClientMessage = typeof ClientMessage.infer;


### PR DESCRIPTION
Part of #26 — implements [`plans/005-harden-realtime-endpoints.md`](https://github.com/hasparus/bear-fit/blob/partyserver/plans/005-harden-realtime-endpoints.md).

Two holes:

1. **`POST /parties/rooms/index` was publicly writable.** It exists only for the editor DO's internal occupancy reports, but `routePartykitRequest` exposes it — anyone could wipe rooms, inflate counts, or spam arbitrary room names into DO storage. Now gated on `url.hostname === "occupancy.internal"` (the editor's DO-stub fetch URL, unreachable through the public router, which forwards the original public URL — verified in partyserver's source) plus an `x-occupancy-internal` header as a self-documenting second factor. Public GET aggregate stays public.
2. **Dashboard auth signatures replayed forever.** The client signed the constant `"dashboard"`; a captured signature worked for all time, and a successful auth reveals the full room map — i.e. event IDs, which are the only thing protecting events. The signed message is now `dashboard:<unix-ms>`, rejected when older than 5 minutes; `.ssh/sign-message.tsx` emits a `<timestamp>.<signature>` token and the dashboard sends both parts.

Spec updates: new test that the public POST returns 403, the happy path seeds room counts through real WebSocket connections instead of the now-forbidden public POST, and a new negative test that a 6-minute-old token never reveals the room list.

Verification: `Dashboard.spec.ts` + `Sync.spec.ts` 10/10 on both browsers (Sync's cross-DO occupancy lifecycle proves the internal channel still works); typecheck, lint, build clean.