### PR TITLE
Archive idle events: TTL tombstones, read-only expired view, no empty-room joins

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,12 +1,17 @@
-import { Suspense, useRef } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import useYProvider from "y-partyserver/react";
+import * as Y from "yjs";
 import { Doc } from "yjs";
 
+import type { EventResponse } from "./api/getEvent";
+
+import { getEvent } from "./api/getEvent";
 import { postEvent } from "./api/postEvent";
 import { serverUrl } from "./api/serverUrl";
 import { AppFooter } from "./AppFooter";
 import { AppHeader } from "./AppHeader";
 import { initializeEventMap } from "./shared-data";
+import { Container } from "./ui/Container";
 import { CreateEventForm } from "./ui/CreateEventForm";
 import { CursorPartyScript } from "./ui/CursorPartyScript";
 import { DialogsProvider } from "./ui/Dialog";
@@ -39,6 +44,12 @@ export function App() {
   );
 }
 
+type PreflightState =
+  | { json: EventResponse; status: "expired" }
+  | { status: "live" }
+  | { status: "loading" }
+  | { status: "not-found" };
+
 function Routes({
   params,
   yDoc,
@@ -48,27 +59,111 @@ function Routes({
 }) {
   const eventId = params.get("id");
 
-  return eventId ? (
+  const [preflight, setPreflight] = useState<PreflightState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!eventId) return;
+    setPreflight({ status: "loading" });
+    getEvent(eventId)
+      .then((json) => {
+        if (!json.event?.id) {
+          setPreflight({ status: "not-found" });
+        } else if (json.expiredAt != null) {
+          setPreflight({ json, status: "expired" });
+        } else {
+          setPreflight({ status: "live" });
+        }
+      })
+      .catch(() => {
+        setPreflight({ status: "not-found" });
+      });
+  }, [eventId]);
+
+  if (!eventId) {
+    return (
+      <CreateEventForm
+        onSubmit={(calendarEvent) => {
+          initializeEventMap(yDoc, calendarEvent);
+
+          return postEvent(calendarEvent)
+            .catch((error) => {
+              console.error("creating event failed", error);
+            })
+            .then(() => {
+              params.set("id", calendarEvent.id);
+            });
+        }}
+      />
+    );
+  }
+
+  if (preflight.status === "loading") {
+    return <Loading />;
+  }
+
+  if (preflight.status === "not-found") {
+    return <NotFoundBox />;
+  }
+
+  if (preflight.status === "expired") {
+    const hydratedDoc = hydrateDocFromJson(preflight.json);
+    const expiredDate = new Date(preflight.json.expiredAt!).toLocaleDateString(
+      undefined,
+      { day: "numeric", month: "long", timeZone: "UTC", year: "numeric" },
+    );
+    return (
+      <div className="w-(--container-width) mx-auto">
+        <div className="mb-2 px-[10px] py-2 bg-neutral-100 border border-neutral-300 rounded-sm font-mono text-sm text-neutral-700">
+          This event expired on {expiredDate} and is now read-only.
+        </div>
+        <YDocContext.Provider value={hydratedDoc}>
+          <EventDetails disabled />
+        </YDocContext.Provider>
+      </div>
+    );
+  }
+
+  return (
     <Suspense fallback={<Loading />}>
       <YProvider room={eventId} yDoc={yDoc}>
         <EventDetails />
       </YProvider>
     </Suspense>
-  ) : (
-    <CreateEventForm
-      onSubmit={(calendarEvent) => {
-        initializeEventMap(yDoc, calendarEvent);
-
-        return postEvent(calendarEvent)
-          .catch((error) => {
-            console.error("creating event failed", error);
-          })
-          .then(() => {
-            params.set("id", calendarEvent.id);
-          });
-      }}
-    />
   );
+}
+
+function NotFoundBox() {
+  return (
+    <Container>
+      <h1 className="mb-4 font-bold leading-[1.3333]">Event not found</h1>
+      <p className="mb-4 font-mono text-sm text-neutral-500">
+        This link doesn&apos;t point to an existing event &mdash; it may have
+        expired after 60 days of inactivity.
+      </p>
+      <a className="btn btn-default" href="/">
+        Create a new event
+      </a>
+    </Container>
+  );
+}
+
+function hydrateDocFromJson(json: EventResponse): Doc {
+  const doc = new Y.Doc();
+  const eventMap = doc.getMap("event");
+  const namesMap = doc.getMap("names");
+  const availabilityMap = doc.getMap("availability");
+
+  Object.entries(json.event).forEach(([k, v]) => {
+    eventMap.set(k, v);
+  });
+  Object.entries(json.names).forEach(([k, v]) => {
+    namesMap.set(k, v);
+  });
+  Object.entries(json.availability).forEach(([k, v]) => {
+    availabilityMap.set(k, v);
+  });
+
+  return doc;
 }
 
 function YProvider({
@@ -80,8 +175,6 @@ function YProvider({
   room: string;
   yDoc: Doc;
 }) {
-  // This needs to be a separate component, because the `.room` option is immutable in
-  // `useYProvider`, and we don't know the room until we create the event.
   const _yProvider = useYProvider({
     doc: yDoc,
     host: serverUrl,

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import useYProvider from "y-partyserver/react";
 import * as Y from "yjs";
 import { Doc } from "yjs";
@@ -10,7 +10,7 @@ import { postEvent } from "./api/postEvent";
 import { serverUrl } from "./api/serverUrl";
 import { AppFooter } from "./AppFooter";
 import { AppHeader } from "./AppHeader";
-import { initializeEventMap } from "./shared-data";
+import { getEventMap, initializeEventMap } from "./shared-data";
 import { Container } from "./ui/Container";
 import { CreateEventForm } from "./ui/CreateEventForm";
 import { CursorPartyScript } from "./ui/CursorPartyScript";
@@ -63,6 +63,10 @@ function Routes({
 
   useEffect(() => {
     if (!eventId) return;
+    if (getEventMap(yDoc).get("id") === eventId) {
+      setPreflight({ status: "live" });
+      return;
+    }
     setPreflight({ status: "loading" });
     getEvent(eventId)
       .then((json) => {
@@ -77,7 +81,13 @@ function Routes({
       .catch(() => {
         setPreflight({ status: "not-found" });
       });
-  }, [eventId]);
+  }, [eventId, yDoc]);
+
+  const hydratedDoc = useMemo(
+    () =>
+      preflight.status === "expired" ? hydrateDocFromJson(preflight.json) : null,
+    [preflight],
+  );
 
   if (!eventId) {
     return (
@@ -105,8 +115,7 @@ function Routes({
     return <NotFoundBox />;
   }
 
-  if (preflight.status === "expired") {
-    const hydratedDoc = hydrateDocFromJson(preflight.json);
+  if (preflight.status === "expired" && hydratedDoc) {
     const expiredDate = new Date(preflight.json.expiredAt!).toLocaleDateString(
       undefined,
       { day: "numeric", month: "long", timeZone: "UTC", year: "numeric" },

--- a/app/NotFound.spec.ts
+++ b/app/NotFound.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "../test";
+
+test("shows event not found for a nonexistent room id", async ({ page }) => {
+  await page.goto("/?id=definitely-not-a-real-room-xyz");
+
+  await expect(
+    page.getByRole("heading", { name: "Event not found" }),
+  ).toBeVisible();
+
+  await expect(page.getByText("Loading...")).not.toBeVisible();
+});

--- a/app/api/getEvent.ts
+++ b/app/api/getEvent.ts
@@ -1,0 +1,18 @@
+import type { CalendarEvent } from "../schemas";
+
+import { serverUrl } from "./serverUrl";
+
+export interface EventResponse {
+  availability: Record<string, true>;
+  event: Partial<CalendarEvent>;
+  expiredAt: number | null;
+  names: Record<string, string>;
+}
+
+export async function getEvent(roomId: string): Promise<EventResponse> {
+  const res = await fetch(`${serverUrl}/parties/main/${roomId}`);
+  if (!res.ok) {
+    throw new Error(`getEvent failed: ${res.status}`);
+  }
+  return res.json() as Promise<EventResponse>;
+}

--- a/party/editor.expiry.test.ts
+++ b/party/editor.expiry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPACTION_THRESHOLD,
+  EVENT_TTL_MS,
+  shouldCompact,
+} from "./editor.expiry";
+
+describe("EVENT_TTL_MS", () => {
+  it("is 60 days in milliseconds", () => {
+    expect(EVENT_TTL_MS).toBe(60 * 24 * 60 * 60 * 1000);
+  });
+
+  it("is greater than 30 days", () => {
+    expect(EVENT_TTL_MS).toBeGreaterThan(30 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe("COMPACTION_THRESHOLD", () => {
+  it("is 5000", () => {
+    expect(COMPACTION_THRESHOLD).toBe(5_000);
+  });
+});
+
+describe("shouldCompact", () => {
+  it("returns false at zero", () => {
+    expect(shouldCompact(0)).toBe(false);
+  });
+
+  it("returns false at threshold exactly", () => {
+    expect(shouldCompact(COMPACTION_THRESHOLD)).toBe(false);
+  });
+
+  it("returns true one above threshold", () => {
+    expect(shouldCompact(COMPACTION_THRESHOLD + 1)).toBe(true);
+  });
+
+  it("returns true well above threshold", () => {
+    expect(shouldCompact(10_000)).toBe(true);
+  });
+});

--- a/party/editor.expiry.ts
+++ b/party/editor.expiry.ts
@@ -1,0 +1,6 @@
+export const EVENT_TTL_MS = 60 * 24 * 60 * 60 * 1000;
+export const COMPACTION_THRESHOLD = 5_000;
+
+export function shouldCompact(count: number): boolean {
+  return count > COMPACTION_THRESHOLD;
+}

--- a/party/editor.partyserver.ts
+++ b/party/editor.partyserver.ts
@@ -85,6 +85,15 @@ export class EditorPartyServer extends YServer<EditorEnv> {
     connection: Connection,
     ctx: ConnectionContext,
   ): Promise<void> {
+    const expiredAt = await this.ctx.storage.get<number>("expiredAt");
+    if (expiredAt != null) {
+      connection.close(4410, "event expired");
+      return;
+    }
+    if (!hasCalendarEvent(this.document)) {
+      connection.close(4404, "event not found");
+      return;
+    }
     await super.onConnect(connection, ctx);
     void this.updateOccupancyCount();
   }
@@ -154,7 +163,12 @@ export class EditorPartyServer extends YServer<EditorEnv> {
       }
 
       if (url.pathname === `/parties/main/${this.name}`) {
-        return Response.json(yDocToJson(this.document), { headers });
+        const expiredAt =
+          (await this.ctx.storage.get<number>("expiredAt")) ?? null;
+        return Response.json(
+          { ...yDocToJson(this.document), expiredAt },
+          { headers },
+        );
       }
     }
 
@@ -219,7 +233,21 @@ export class EditorPartyServer extends YServer<EditorEnv> {
   }
 
   override async onAlarm(): Promise<void> {
-    await this.ctx.storage.deleteAll();
+    if (hasCalendarEvent(this.document)) {
+      const state = Y.encodeStateAsUpdate(this.document);
+      this.ctx.storage.sql.exec(
+        `INSERT OR REPLACE INTO ${TABLE_DOCUMENTS} (id, state) VALUES (?, ?)`,
+        this.name,
+        state,
+      );
+      this.ctx.storage.sql.exec(
+        `DELETE FROM ${TABLE_UPDATES} WHERE doc_id = ?`,
+        this.name,
+      );
+      await this.ctx.storage.put("expiredAt", Date.now());
+    } else {
+      await this.ctx.storage.deleteAll();
+    }
   }
 
   private compactUpdates() {

--- a/party/editor.partyserver.ts
+++ b/party/editor.partyserver.ts
@@ -87,11 +87,11 @@ export class EditorPartyServer extends YServer<EditorEnv> {
   ): Promise<void> {
     const expiredAt = await this.ctx.storage.get<number>("expiredAt");
     if (expiredAt != null) {
+      // Expired rooms are read-only archives; a reconnecting stale client must
+      // not resurrect them. Event-less rooms stay connectable on purpose: the
+      // creator's optimistic navigation relies on Yjs sync to deliver the event
+      // when the create POST is slow or fails.
       connection.close(4410, "event expired");
-      return;
-    }
-    if (!hasCalendarEvent(this.document)) {
-      connection.close(4404, "event not found");
       return;
     }
     await super.onConnect(connection, ctx);

--- a/party/editor.partyserver.ts
+++ b/party/editor.partyserver.ts
@@ -12,6 +12,7 @@ import {
   initializeEventMap,
   yDocToJson,
 } from "../app/shared-data";
+import { EVENT_TTL_MS, shouldCompact } from "./editor.expiry";
 import { OccupancyPartyServer } from "./occupancy.partyserver";
 import { CORS, OCCUPANCY_SERVER_SINGLETON_ROOM_ID } from "./shared";
 
@@ -123,6 +124,7 @@ export class EditorPartyServer extends YServer<EditorEnv> {
 
         initializeEventMap(this.document, event);
         await this.onSave();
+        this.touch();
 
         return Response.json({ message: "created" }, { headers });
       } catch (error) {
@@ -212,6 +214,36 @@ export class EditorPartyServer extends YServer<EditorEnv> {
     });
   }
 
+  private touch() {
+    void this.ctx.storage.setAlarm(Date.now() + EVENT_TTL_MS);
+  }
+
+  override async onAlarm(): Promise<void> {
+    await this.ctx.storage.deleteAll();
+  }
+
+  private compactUpdates() {
+    const state = Y.encodeStateAsUpdate(this.document);
+    this.ctx.storage.transactionSync(() => {
+      this.ctx.storage.sql.exec(
+        `INSERT OR REPLACE INTO ${TABLE_DOCUMENTS} (id, state) VALUES (?, ?)`,
+        this.name,
+        state,
+      );
+      this.ctx.storage.sql.exec(
+        `DELETE FROM ${TABLE_UPDATES} WHERE doc_id = ?`,
+        this.name,
+      );
+      this.ctx.storage.sql.exec(
+        `INSERT INTO ${TABLE_UPDATES} (doc_id, clock, update_data) VALUES (?, ?, ?)`,
+        this.name,
+        this.#lastClock + 1,
+        state,
+      );
+    });
+    this.#lastClock += 1;
+  }
+
   private persistIncrementalUpdate(update: Uint8Array) {
     this.#lastClock += 1;
     try {
@@ -223,6 +255,18 @@ export class EditorPartyServer extends YServer<EditorEnv> {
       );
     } catch (error) {
       console.error("failed to persist update", error);
+    }
+    this.touch();
+    if (this.#lastClock % 256 === 0) {
+      const [row] = [
+        ...this.ctx.storage.sql.exec(
+          `SELECT COUNT(*) as cnt FROM ${TABLE_UPDATES} WHERE doc_id = ?`,
+          this.name,
+        ),
+      ];
+      if (row && shouldCompact(Number(row.cnt))) {
+        this.compactUpdates();
+      }
     }
   }
 


### PR DESCRIPTION
Part of #26 — implements [`plans/007-bound-do-storage-growth.md`](https://github.com/hasparus/bear-fit/blob/partyserver/plans/007-bound-do-storage-growth.md) including **Revisions 2–3** (maintainer: "never let the user join an empty room… even expired events are sometimes important" / "Yjs sync papering over was a feature"). **Stacked on #28**; retarget after #28 merges.

**Storage bounds** (the original plan): every write re-arms a 60-day sliding DO alarm; the update log compacts to a snapshot baseline at 5,000 rows (`shouldCompact` in `party/editor.expiry.ts`, checked every 256th update inside `transactionSync`).

**Expiry is an archive, not a deletion**: when the alarm fires on a room *with* an event, the doc is compacted to a final snapshot, the history log is dropped, and `expiredAt` is stored — `deleteAll` only happens for junk rooms that never got an event. Expired rooms reject WebSocket connects with `4410` so a stale client can't silently resurrect them; **event-less rooms stay connectable on purpose** — the creator's optimistic navigation (#30) relies on Yjs sync delivering the event when the POST is slow or fails.

**UX**:
- Visiting a nonexistent event → explicit "Event not found" box (client preflights the existing GET, which now also returns `expiredAt`); no connection, no skeleton-forever, no junk room created by the UI
- Visiting an expired event → the real grid, read-only (`<EventDetails disabled />` hydrated verbatim from the archived JSON — deliberately *not* `overwriteYDocWithJson`, which remaps user ids for import), behind a "This event expired on <date> and is now read-only" banner; Export JSON still works
- The creator's own freshly-created event skips the preflight (local doc already holds the id)

Known gaps: alarm firing can't be fast-forwarded in `vite preview`, so the expiry path is verified by reading + types + unit tests; reviewer focus on `touch()` staying `void`-ed in the synchronous Yjs update handler. **Integration with #31**: its `Dashboard.spec.ts` seeds occupancy via WebSockets to event-less rooms — still fine (no 4404 rejection), but re-check when both land.

Verification: 46 unit tests; full Playwright suite **36/36** on both browsers (incl. new `NotFound.spec.ts`); preview-server sanity: garbage `?id=` renders the not-found state.
