### PR TITLE
Fix EventDatesPicker disabled date logic for rolling ranges

### DIFF
--- a/app/ui/EventDatesPicker.tsx
+++ b/app/ui/EventDatesPicker.tsx
@@ -118,9 +118,7 @@ export function EventDatesPicker({
         onSelect={handleRangeSelect}
         selected={selected}
         disabled={
-          value.isRolling
-            ? { before: addDays(today, 1) }
-            : fixedRangeProps?.disabled
+          value.isRolling ? { before: today } : fixedRangeProps?.disabled
         }
       />
       <CheckboxField


### PR DESCRIPTION
## Summary
Updated the disabled date logic in EventDatesPicker to correctly handle rolling date ranges by disabling dates before today instead of before tomorrow.

## Key Changes
- Changed the `before` constraint from `addDays(today, 1)` to `today` when `value.isRolling` is true
- This allows today's date to be selectable in rolling date range mode, while still preventing selection of past dates

## Implementation Details
The disabled dates configuration for the DateRangePicker now correctly prevents users from selecting dates prior to today (inclusive) when using a rolling date range, rather than preventing selection of today itself. This aligns the behavior with the expected UX for rolling date ranges where the current day should be available as a valid selection boundary.

https://claude.ai/code/session_01Ncj9rbszKRVhGMZuPDjgNx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the earliest selectable date in rolling mode for the date picker by one day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->